### PR TITLE
Check for an empty domain before proceeding

### DIFF
--- a/main.go
+++ b/main.go
@@ -59,6 +59,10 @@ func doCertCheckAndRenewal(ctx context.Context) error {
 		return fmt.Errorf("failed to get tailscale domain: %w", err)
 	}
 
+	if domain == "" {
+		return errors.New("tailscale domain is empty")
+	}
+
 	ssl := sslpaths.NewSSLPaths("/etc/kvmd/nginx/ssl/", domain)
 
 	certManager := certmanager.NewCertManager(ssl)


### PR DESCRIPTION
Fix for
```
Jul 17 10:18:56 pikvm pikvm-tailscale-cert-renewer[531]: 2024/07/17 10:18:56 WARN cert file does not exist path=/etc/kvmd/nginx/ssl/.crt
Jul 17 10:18:56 pikvm pikvm-tailscale-cert-renewer[531]: 2024/07/17 10:18:56 ERROR failed to check or renew cert time_until_retry=1m0s err>
```

It looks like this might happen on reboot. I wonder if there is a tailscale service I should be waiting for in the systemd template...?