### PR TITLE
start after and require tailscaled service

### DIFF
--- a/pikvm-tailscale-certificate-renewer.service
+++ b/pikvm-tailscale-certificate-renewer.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=PiKVM Tailscale Certificate Renewer
-After=network.target
+Requires=tailscaled.service
+After=tailscaled.service
 
 [Service]
 Type=notify


### PR DESCRIPTION
Follow up to #6 

This PR modifies the systemd service definition to start the cert renewer after tailscaled. This change may prevent tailscale local api from returning empty domains because it's not yet running.